### PR TITLE
Support for DSE Contact Points Env Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ Enterprise). You can start those dependencies with:
 
 The app generates sample video data to insert into KillrVideo by searching YouTube for videos matching keywords specified in `src/youtube/sources.js`. Calling the YouTube Data API requires  authentication, which for the generator is an API key. In order to run the generator from your local environment you will need to get an API key from the [Google Developer Console](https://console.developers.google.com/). 
 
-Create a new project, select it, and expand APIs and Auth. In the list of APIs, enable YouTube Data API (v3) and under credentials select to create a new browser key. Now create the file `config/local.yaml` and add your API key:
+Create a new project, select it, and expand APIs and Auth. In the list of APIs, enable YouTube Data API (v3) and under credentials select to create a new browser key. Now open the file `docker-compose.yaml` and add your API key:
  ```
-youTubeApiKey: <YOUR API KEY> 
+ services:
+  generator:
+    environment:
+      KILLRVIDEO_YOUTUBE_API_KEY: <YOUR API KEY> 
 ```
 
 ## Developing
@@ -54,7 +57,28 @@ allow you to start the program with debugging using `F5`.
 
 By default docker-compose runs generator with debugger enabled and opens port 5858. You can use this to attach to the launched application to debug it.
 
-If you would like to use DataStax Studio to work directly with the database, please uncomment studio definition in ./docker-compose.yaml
+## Environment Variables
+
+To change behaviour of the application you can configure environment variables in docker-compose file. For example, you can configure the application to work with your own cassandra cluster instead of the 'built-in' dockerized one. Add the variable to a docker-compose file like here:
+```
+version: '3'
+services:
+  generator:
+    ...
+    environment:
+      KILLRVIDEO_DSE_CONTACT_POINTS: 192.168.15.17
+```
+
+### Available Environment Variables
+```
+Logging Level       KILLRVIDEO_LOGGING_LEVEL          verbose
+YouTube API Key     KILLRVIDEO_YOUTUBE_API_KEY        REPLACE_WITH_YOUR_KEY
+Cassandra Host      KILLRVIDEO_DSE_CONTACT_POINTS     dse
+Replication Factor  KILLRVIDEO_CASSANDRA_REPLICATION  "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+Generator Keyspace  KILLRVIDEO_CASSANDRA_KEYSPACE     killrvideo_sample_data
+Username            KILLRVIDEO_DSE_USERNAME           Null
+Password            KILLRVIDEO_DSE_PASSWORD           Null
+````
 
 ## Releasing
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -8,3 +8,6 @@ cassandra:
   dsePassword: KILLRVIDEO_DSE_PASSWORD
 
 loggingLevel: KILLRVIDEO_LOGGING_LEVEL
+
+services:
+  cassandra: KILLRVIDEO_DSE_CONTACT_POINTS

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -34,14 +34,14 @@ schedules:
   - every 1 seconds
 
 services:
-  web:                    ['web:3000']
-  cassandra:              ['dse:9042']
-  dse-search:             ['dse:8983']
-  UploadsService:         ['backend:50101']
-  RatingsService:         ['backend:50101']
-  CommentsService:        ['backend:50101']
-  SearchService:          ['backend:50101']
-  StatisticsService:      ['backend:50101']
-  VideoCatalogService:    ['backend:50101']
-  UserManagementService:  ['backend:50101']
-  SuggestedVideoService:  ['backend:50101']
+  web:                    'web:3000'
+  cassandra:              'dse:9042'
+  dse-search:             'dse:8983'
+  UploadsService:         'backend:50101'
+  RatingsService:         'backend:50101'
+  CommentsService:        'backend:50101'
+  SearchService:          'backend:50101'
+  StatisticsService:      'backend:50101'
+  VideoCatalogService:    'backend:50101'
+  UserManagementService:  'backend:50101'
+  SuggestedVideoService:  'backend:50101'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,13 +12,14 @@ services:
       - dse
       - backend
     environment:
+      KILLRVIDEO_YOUTUBE_API_KEY: SET_YOUR_YOUTUBE_KEY_HERE
       KILLRVIDEO_LOGGING_LEVEL: debug
     command: "node --debug /opt/killrvideo-generator/dist/index.js"
 
   # DataStax Enterprise
   # start with search and graph modes enabled ("-s -g")
   dse:
-    image: datastax/dse-server:6.0.0
+    image: datastax/dse-server:6.7.0
     command: [ -s -g ]
     ports:
     - "9042:9042"
@@ -36,15 +37,13 @@ services:
   # Provides options to configure secure users as well
   # Runs only once and exits
   dse-config:
-    image: killrvideo/killrvideo-dse-config:2.2.1
+    image: killrvideo/killrvideo-dse-config:3.0.0
     depends_on:
       - dse
-    environment:
-      KILLRVIDEO_SERVICE_DISCOVERY_DISABLED: 'true'
 
   # The KillrVideo backend application used by the generator to submit sample data
   backend:
-    image: hadesarchitect/killrvideo-nodejs:no-etcd
+    image: killrvideo/killrvideo-nodejs:3.0.0
     ports:
       - "50101:50101"
     depends_on:

--- a/src/utils/lookup-service.js
+++ b/src/utils/lookup-service.js
@@ -27,5 +27,5 @@ export function lookupServiceAsync(serviceName) {
 
   logger.log('verbose', `Found service ${serviceName} at ${registry[serviceName]}`);
 
-  return new Promise (function(resolve, reject){resolve(registry[serviceName])});
+  return new Promise (function(resolve, reject){resolve([registry[serviceName]])});
 };


### PR DESCRIPTION
**Done**
- Added support for DSE Contact Points Env Variable
- Simplified setup for a YouTube API key 
- Updated versions in docker-compose.yaml

**To test**
- Review changes
- clone locally & build as described in README
- run without any changes (KILLRVIDEO_DSE_CONTACT_POINTS falls back to a default dse value),  SHOULD WORK (docker-compose logs -f generator, generator works)
- run with Env Var defined to an invalid value (KILLRVIDEO_DSE_CONTACT_POINTS=lolwut), SHOULD FAIL
- run with Env Var defined to an valid value (KILLRVIDEO_DSE_CONTACT_POINTS=dse OR KILLRVIDEO_DSE_CONTACT_POINTS=YOURREALCLUSTER), SHOULD WORK