### PR TITLE
CD Improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ after_success:
 - docker tag ${TRAVIS_COMMIT} killrvideo/killrvideo-generator:${TRAVIS_TAG}
 - docker login -u $DOCKER_USER -p $DOCKER_PASS
 - docker push killrvideo/killrvideo-generator:${TRAVIS_TAG}
+- "[ \"$(git tag --sort=-v:refname | grep -P \"^\\d+.\\d+.\\d+$\" | head -n1)\" == \"$TRAVIS_TAG\" ] && { docker tag ${TRAVIS_COMMIT} killrvideo/killrvideo-generator:latest; docker push killrvideo/killrvideo-generator:latest; }"
+- "[ \"$(git tag --sort=-v:refname | grep -P \"^\\d+.\\d+.\\d+$\" | head -n1)\" == \"$TRAVIS_TAG\" ] && { docker tag ${TRAVIS_COMMIT} killrvideo/killrvideo-generator:$(echo $TRAVIS_TAG | cut -d'.' -f 1); docker push killrvideo/killrvideo-generator:$(echo $TRAVIS_TAG | cut -d'.' -f 1); }"
+- "[ \"$(git tag --sort=-v:refname | grep -P \"^\\d+.\\d+.\\d+$\" | head -n1)\" == \"$TRAVIS_TAG\" ] && { docker tag ${TRAVIS_COMMIT} killrvideo/killrvideo-generator:$(echo $TRAVIS_TAG | cut -d'.' -f 1).$(echo $TRAVIS_TAG | cut -d'.' -f 2); docker push killrvideo/killrvideo-generator:$(echo $TRAVIS_TAG | cut -d'.' -f 1).$(echo $TRAVIS_TAG | cut -d'.' -f 2); }"
 
 # Sudo required for doing docker build
 sudo: required


### PR DESCRIPTION
To push the latest tag as a docker image tagged like:
- Exact tag, f.e. `:3.0.3`
- Latest tag, `:latest`
- Latest minor release, f.e. `:3.0` 
- Latest major release, f.e. `:3`

Following this, we can set docker-compose files of multiple projects to use weaker version reqs like `:3` or `3.1` instead of too restrictive `3.1.5`, so we don't have to update 6 repos after the release of a minor update, like I do now.

Example usage: https://github.com/KillrVideo/killrvideo-all-in-one/blob/master/docker-compose.yml#L57

![image](https://user-images.githubusercontent.com/1742301/77903077-90ddee80-7282-11ea-9bac-0bab42c4b6c7.png)